### PR TITLE
Use type instead of class as dispatch function

### DIFF
--- a/src/schema_gen/core.clj
+++ b/src/schema_gen/core.clj
@@ -39,7 +39,7 @@
      (remove #(= % :default))))
 
 (defmulti schema->gen  identity)
-(defmulti schema->gen* class)
+(defmulti schema->gen* type)
 
 (defmethod schema->gen :default
   [e]


### PR DESCRIPTION
This gives a little more flexibility in extending the multimethod, since
we can customize the "type" of schema's defrecords via `:type` metadata.