### PR TITLE
Fix for Clojure 1.7.0-beta2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.gfredericks/test.chuck "0.1.14"]
+                 [com.gfredericks/test.chuck "0.1.17"]
                  [prismatic/schema "0.3.7"]
                  [org.clojure/test.check "0.7.0"]]
   :lein-release {:deploy-via :shell


### PR DESCRIPTION
Allow use in Clojure 1.7.0-beta2 by updating com.gfredricks/test from 0.1.14 to 0.1.17. See https://github.com/clojure-emacs/refactor-nrepl/issues/53 for details.
